### PR TITLE
Modificado shebang python

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,18 @@ $ git clone https://github.com/janssenlima/ZabbixTuner
 $ cd ZabbixTuner
 $ sudo pip install -r requirements.txt
 ```
+### Instalação com venv no python3
+
+```sh
+$ sudo apt-get install python-pip git
+
+$ git clone https://github.com/janssenlima/ZabbixTuner
+$ cd ZabbixTuner
+$ python -m venv ./venv
+$ source ./venv/bin/activate
+$ pip install -r requirements.txt
+$ ./ZabbixTuner.py
+```
 
 ## Configurar parâmetros de conexão do Zabbix
 

--- a/ZabbixTuner.py
+++ b/ZabbixTuner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 __author__    = "Janssen dos Reis Lima"
 


### PR DESCRIPTION
Olá Janssen,

Fiz uma pequena alteração no arquivo principal, alterando o shebang utilizado para `#!/usr/bin/env python`, instruindo dessa forma o script a utilizar o python configurado no PATH do sistema, permitindo a execução em ambientes virtuais.